### PR TITLE
Updated index.less for depreciation due to Atom v1.13.0.

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,6 +1,6 @@
 @import 'styles/syntax-variables';
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
 
   .find-result .region {
     background-color: transparent;
@@ -18,7 +18,7 @@ atom-text-editor::shadow {
 
 }
 
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -112,41 +112,41 @@ atom-text-editor, :host {
 
   // ===================
 
-  .gfm {
-    .markup {
-      &.heading {
+  .syntax--gfm {
+    .syntax--markup {
+      &.syntax--heading {
         color: #A6E22E;
         font-weight: bold;
       }
 
-      &.underline {
+      &.syntax--underline {
         color: #E6DB74;
         text-decoration: underline;
       }
     }
 
-    .bold {
+    .syntax--bold {
       font-weight: bold;
     }
 
-    .italic {
+    .syntax--italic {
       font-style: italic;
     }
 
-    .raw {
+    .syntax--raw {
       color: #66D9EF;
     }
 
-    .variable.list {
+    .syntax--variable.syntax--list {
       color: #F92672;
       font-weight: bold;
     }
 
-    .link.underline,
-    .link {
+    .syntax--link.syntax--underline,
+    .syntax--link {
       color: #666;
 
-      .entity {
+      .syntax--entity {
         color: #AE81FF;
       }
     }
@@ -156,24 +156,24 @@ atom-text-editor, :host {
 
 }
 
-.comment {
+.syntax--comment {
   color: #7E8E91;
 }
 
 // ===================
 
-.string {
+.syntax--string {
   color: #A6E22E;
 }
 
-.constant.character.escape {
+.syntax--constant.syntax--character.syntax--escape {
   color: #99ff99;
 }
 
-.regexp {
+.syntax--regexp {
   color: #99ff99;
 
-  .string {
+  .syntax--string {
     color: #99ff99;
   }
 
@@ -181,73 +181,73 @@ atom-text-editor, :host {
 
 // ===================
 
-.support.function.decl {
+.syntax--support.syntax--function.syntax--decl {
   color: #E6DB74;
 }
 
-.entity.other.attribute-name.id {
+.syntax--entity.syntax--other.syntax--attribute-name.syntax--id {
   color: #E6DB74;
 }
 
-.variable.less,
-.variable.scss {
+.syntax--variable.syntax--less,
+.syntax--variable.syntax--scss {
   color: #ffcc00;
 }
 
-.meta.function,
-.meta.method {
+.syntax--meta.syntax--function,
+.syntax--meta.syntax--method {
 
-  .entity.name.method,
-  .entity.name.function {
+  .syntax--entity.syntax--name.syntax--method,
+  .syntax--entity.syntax--name.syntax--function {
     color: #ffcc00;
   }
 
 }
 
-.entity.name.class,
-.entity.other.inherited-class,
-.entity.name.accessor {
+.syntax--entity.syntax--name.syntax--class,
+.syntax--entity.syntax--other.syntax--inherited-class,
+.syntax--entity.syntax--name.syntax--accessor {
   color: #ffcc00;
   text-decoration: none;
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   font-style: italic;
 }
 
 // ===================
 
-.storage.type {
+.syntax--storage.syntax--type{
   font-style: italic;
   color: #66D9EF;
 }
 
-.keyword.control.js {
+.syntax--keyword.syntax--control.syntax--js {
   color: #66D9EF;
 }
 
-.keyword.control.flow {
+.syntax--keyword.syntax--control.syntax--flow {
   color: #66D9EF;
 }
 
-.entity.name.instance {
+.syntax--entity.syntax--name.syntax--instance {
   color: #66D9EF;
 }
 
-.support.constant {
+.syntax--support.syntax--constant {
   color: #66D9EF;
 }
 
-.support.type.property-name {
+.syntax--support.syntax--type.syntax--property-name {
   color: #66D9EF;
   text-decoration: underline;
   font-style: normal;
 }
 
-.meta.function.arrow.js {
+.syntax--meta.syntax--function.syntax--arrow.syntax--js {
   color: #66D9EF;
 
-  .storage.type {
+  .syntax--storage.syntax--type {
     font-style: normal;
   }
 
@@ -255,7 +255,7 @@ atom-text-editor, :host {
 
 // ===================
 
-.variable.parameter {
+.syntax--variable.syntax--parameter {
   font-style: italic;
   color: #FD971F;
 }
@@ -264,159 +264,160 @@ atom-text-editor, :host {
 //   color: #FD971F;
 // }
 
-.entity.other.attribute-name {
+.syntax--entity.syntax--other.syntax--attribute-name {
   color: #FD971F;
 }
 
-.entity.other.attribute-name.jsx {
+.syntax--entity.syntax--other.syntax--attribute-name.syntax--jsx {
   color: #ff6600;
 }
 
-.string.unquoted.label.js {
+.syntax--string.syntax--unquoted.syntax--label.syntax--js {
   color: #ff6600;
 }
 
-.object.key.js {
+.syntax--object.syntax--key.syntax--js {
 
-  .string {
+  .syntax--string {
     color: #ff6600;
   }
 
 }
 
-.meta.structure.dictionary.json:not(.value) > .string.quoted.double.json,
-.meta.structure.dictionary.json:not(.value) > .string.quoted.double.json > .punctuation.definition.string.json {
+.syntax--meta.syntax--structure.syntax--dictionary.syntax--json:not(.value) > .syntax--string.syntax--quoted.syntax--double.syntax--json,
+.syntax--meta.syntax--structure.syntax--dictionary.syntax--json:not(.value) > .syntax--string.syntax--quoted.syntax--double.syntax--json > .syntax--punctuation.syntax--definition.syntax--string.syntax--json {
   color: #FD971F;
 }
 
-.entity.other.pseudo-class {
+.syntax--entity.syntax--other.syntax--pseudo-class {
   color: #ff6600;
 }
 
-.entity.name.function {
+.syntax--entity.syntax--name.syntax--function {
   color: #FD971F;
   font-style: normal;
 }
-.meta.function-call .entity.name.function {
+
+.syntax--meta.syntax--function-call .syntax--entity.syntax--name.syntax--function {
   font-style: normal;
 }
 
 
 // ===================
 
-.constant.numeric {
+.syntax--constant.syntax--numeric {
   color: #AE81FF;
 }
 
-.constant.language {
+.syntax--constant.syntax--language {
   color: #AE81FF;
 }
 
-.constant.character,
-.constant.escape,
-.constant.other {
+.syntax--constant.syntax--character,
+.syntax--constant.syntax--escape,
+.syntax--constant.syntax--other {
   color: #AE81FF;
 }
 
 // Jade syntax
-.class.jade {
+.syntax--class.syntax--jade {
   color: #AE81FF;
 }
 
-.support.constant.property-value {
+.syntax--support.syntax--constant.syntax--property-value {
   color: #AE81FF;
 }
 
-.variable.language.this {
+.syntax--variable.syntax--language.syntax--this {
   color: #AE81FF;
 }
 
-.support.class,
-.support.type {
+.syntax--support.syntax--class,
+.syntax--support.syntax--type {
   font-style: normal;
   color: #AE81FF;
   text-decoration: underline;
 
-  .keyword {
+  .syntax--keyword{
     color: #AE81FF;
   }
 
 }
 
-.entity.name.tag.jsx {
+.syntax--entity.syntax--name.syntax--tag.syntax--jsx {
   color: #AE81FF;
 }
 
 // ===================
 
-.keyword {
+.syntax--keyword {
   color: #F92672;
 }
 
-.storage {
+.syntax--storage {
   color: #F92672;
 }
 
-.entity.name.tag,
-.keyword.control.elements {
+.syntax--entity.syntax--name.syntax--tag,
+.syntax--keyword.syntax--control.syntax--elements {
   color: #F92672;
   text-decoration: underline;
 }
 
-.entity.name.tag.custom,
-.keyword.control.elements.custom {
+.syntax--entity.syntax--name.syntax--tag.syntax--custom, 
+.syntax--keyword.syntax--control.syntax--elements.syntax--custom {
   text-decoration: none;
 }
 
-.keyword.control.at-rule {
+.syntax--keyword.syntax--control.syntax--at-rule {
   color: #F92672;
 }
 
-.punctuation.terminator.statement.js {
+.syntax--punctuation.syntax--terminator.syntax--statement.syntax--js {
   color: #F92672;
 }
 
-.meta.delimiter.comma.js {
+.syntax--meta.syntax--delimiter.syntax--comma.syntax--js {
   color: #F92672;
 }
 
-.punctuation.separator.key-value.js {
+.syntax--punctuation.syntax--separator.syntax--key-value.syntax--js {
   color: #F92672;
 }
 
 // ===================
 
-.meta .braces,
-.meta .brace {
+.syntax--meta .syntax--braces, 
+.syntax--meta .syntax--brace {
   color: #FFFFFF;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #ffffff;
   text-decoration: underline;
 }
 
-.keyword.operator.bracket,
-.keyword.operator.punctuation,
+.syntax--keyword.syntax--operator.syntax--bracket, 
+.syntax--keyword.syntax--operator.syntax--punctuation,
  {
   color: #FFFFFF;
 }
 
-.invalid {
+.syntax--invalid {
   color: #F8F8F0;
   background-color: #F92672;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   color: #F8F8F0;
   background-color: #AE81FF;
 }
 
-.meta.function.arrow.js {
+.syntax--meta.syntax--function.syntax--arrow.syntax--js {
 
-  .parameters,
-  .separator,
-  .variable {
+  .syntax--parameters,
+  .syntax--separator,
+  .syntax--variable {
     color: #ffffff;
   }
 
@@ -438,7 +439,7 @@ atom-text-editor, :host {
 
 autocomplete-suggestion-list {
 
-  .word {
+  .syntax--word {
     color: #999;
   }
 


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary.